### PR TITLE
Rename epel package for centos7

### DIFF
--- a/recipes/install_rpm.rb
+++ b/recipes/install_rpm.rb
@@ -28,7 +28,7 @@ package_list = case node['platform']
                  %w(clamav clamav-update clamd)
                else
                  if node['platform_version'].to_i >= 7
-                   %w(clamav-server clamav clamav-update)
+                   %w(clamd clamav clamav-update)
                  else
                    %w(clamav clamav-db clamd)
                  end


### PR DESCRIPTION
clamav-server was renamed to clamd as per https://lists.fedoraproject.org/archives/list/epel-package-announce@lists.fedoraproject.org/message/TDCTWKDGHB2JYKPUYJDC2BGDZ5HNLF2I/